### PR TITLE
Update LangGraph documentation to reflect parallel static risk models

### DIFF
--- a/documentation/gene_know_langgraph.md
+++ b/documentation/gene_know_langgraph.md
@@ -10,15 +10,86 @@ GeneKnow is a local-first genomic risk assessment platform focused on interpreti
 
 ```mermaid
 flowchart TD
-    A["File Input"] --> B["Preprocess Validate + Parse File"]
-    B --> C["Variant QC filter low confidence"] & D["Variant Caller DeepVariant Samtools"]
-    D --> E["Variant Mapper ← reference genome + TCGA"]
-    E --> F["Disease Risk Model TensorFlow TCGA + 1000 Genomes"]
-    F --> G["Interpret Results JSON Output"]
-    G --> H["LLM Report Writer markdown pdf json ← Llama 3.1"]
-    H --> I["Visualizations + Frontend charts heatmaps tables ← React + Tailwind"]
-    C --> F
+    A["File Input<br/>FASTQ/BAM/VCF/MAF"] --> B["Preprocess<br/>Validate + Parse File"]
+    B --> C["Variant QC Filter<br/>Low Confidence"] & D["Variant Calling<br/>DeepVariant/Samtools"]
+    C --> E["Merge Parallel<br/>Variant Consolidation"]
+    D --> E
+    E --> F["Population Mapper<br/>gnomAD/1000G Frequencies"]
+    
+    F --> G["TCGA Mapper<br/>Cancer Frequency Match"]
+    F --> H["CADD Scoring<br/>Variant Deleteriousness"]
+    F --> I["ClinVar Annotator<br/>Clinical Significance"]
+    F --> J["PRS Calculator<br/>Polygenic Risk Score"]
+    F --> K["Pathway Burden<br/>Gene/Pathway Analysis"]
+    
+    G --> L["Merge Static Models<br/>Feature Consolidation"]
+    H --> L
+    I --> L
+    J --> L
+    K --> L
+    
+    L --> M["Feature Vector Builder<br/>ML Input Preparation"]
+    M --> N["Risk Model<br/>TensorFlow ML Prediction"]
+    N --> O["Formatter<br/>JSON Structure"]
+    O --> P["Report Writer<br/>Markdown/PDF Generation"]
+    P --> Q["Frontend Visualizations<br/>React + Tailwind"]
+    
+    style G fill:#e1f5fe
+    style H fill:#e8f5e8
+    style I fill:#fff3e0
+    style J fill:#fce4ec
+    style K fill:#f3e5f5
+    style L fill:#fff9c4
 ```
+
+---
+
+## 🏗️ Static Risk Model Architecture
+
+The updated pipeline now features **5 static risk models operating in parallel** after population mapping:
+
+### 🔄 Parallel Static Models
+
+1. **🧬 TCGA Mapper** - Matches variants against cancer tumor frequencies from TCGA cohorts
+2. **⚡ CADD Scoring** - Assigns deleteriousness scores to variants (PHRED-scaled)
+3. **🏥 ClinVar Annotator** - Provides clinical significance annotations for known variants
+4. **🧮 PRS Calculator** - Computes polygenic risk scores from genome-wide association studies
+5. **🔬 Pathway Burden** - Analyzes gene/pathway-level variant burden for cancer-related pathways
+
+### 🔗 Integration Flow
+
+```mermaid
+flowchart LR
+    A["Population Mapper"] --> B["5 Static Models<br/>Execute in Parallel"]
+    B --> C["Merge Static Models<br/>Feature Consolidation"]
+    C --> D["Feature Vector Builder<br/>ML Input Preparation"]
+    D --> E["Risk Model<br/>TensorFlow Prediction"]
+    
+    B1["TCGA Mapper<br/>🧬"] --> C
+    B2["CADD Scoring<br/>⚡"] --> C
+    B3["ClinVar Annotator<br/>🏥"] --> C
+    B4["PRS Calculator<br/>🧮"] --> C
+    B5["Pathway Burden<br/>🔬"] --> C
+    
+    B --> B1
+    B --> B2
+    B --> B3
+    B --> B4
+    B --> B5
+    
+    style B fill:#fff9c4
+    style C fill:#e8f5e8
+```
+
+### 📊 Output Integration
+
+Each static model contributes specific features to the final risk calculation:
+
+- **TCGA Mapper**: Tumor frequency scores and cancer type associations
+- **CADD Scoring**: Variant deleteriousness scores (0-40 PHRED scale)
+- **ClinVar Annotator**: Clinical significance scores and pathogenicity flags
+- **PRS Calculator**: Polygenic risk scores and percentile rankings
+- **Pathway Burden**: Gene set enrichment scores and pathway disruption metrics
 
 ---
 

--- a/geneknow_pipeline/README.md
+++ b/geneknow_pipeline/README.md
@@ -7,18 +7,22 @@ A genomic risk assessment pipeline built with LangGraph for processing FASTQ, BA
 **All nodes have real implementations!** No more mock data.
 **Enhanced API Server available** with real-time progress tracking and WebSocket support!
 
-### ✅ Implemented Nodes (10/10)
+### ✅ Implemented Nodes (14/14)
 
 1. **file_input** - BioPython/pysam validation
 2. **preprocess** - BWA alignment for FASTQ, VCF variant loading, MAF parsing
 3. **variant_calling** - VCF parsing with simulated variants
 4. **qc_filter** - Quality filtering (QUAL≥30, Depth≥10, AF≥0.01)
 5. **population_mapper** - Population frequency comparison
-6. **cadd_scoring** - CADD PHRED score enrichment for variant deleteriousness
-7. **feature_vector_builder** - Combines outputs from static models (stub)
-8. **risk_model** - Scikit-learn ML models trained on cancer genes
-9. **formatter** - JSON structuring for frontend
-10. **report_writer** - Structured report sections for frontend
+6. **tcga_mapper** - TCGA cancer frequency matching and tumor enrichment
+7. **cadd_scoring** - CADD PHRED score enrichment for variant deleteriousness
+8. **clinvar_annotator** - Clinical significance annotations from ClinVar database
+9. **prs_calculator** - Polygenic Risk Score calculation from GWAS data
+10. **pathway_burden** - Gene/pathway-level variant burden analysis
+11. **feature_vector_builder** - Combines outputs from static models for ML input
+12. **risk_model** - Scikit-learn ML models trained on cancer genes
+13. **formatter** - JSON structuring for frontend
+14. **report_writer** - Structured report sections for frontend
 
 ### 🔄 Pipeline Architecture
 
@@ -33,11 +37,18 @@ Preprocess (Alignment/Variant Loading/MAF Parsing)
     ↓
 Merge Parallel Results
     ↓
-Population Mapper → CADD Scoring → Feature Vector Builder
+Population Mapper
     ↓
-[Conditional: USE_LEGACY_RISK env var]
-  ├─→ Risk Model → Formatter (if legacy)
-  └─→ Formatter (if new architecture)
+[5 Static Models - Execute in Parallel]
+  ├─→ TCGA Mapper (Cancer Frequency Match)
+  ├─→ CADD Scoring (Variant Deleteriousness)
+  ├─→ ClinVar Annotator (Clinical Significance)
+  ├─→ PRS Calculator (Polygenic Risk Score)
+  └─→ Pathway Burden (Gene/Pathway Analysis)
+    ↓
+Merge Static Models (Feature Consolidation)
+    ↓
+Feature Vector Builder → Risk Model → Formatter
     ↓
 Report Writer
 ```


### PR DESCRIPTION
- Updated main LangGraph flow diagram showing 5 static models in parallel
- Added comprehensive static risk model architecture section
- Created detailed integration flow diagram
- Updated pipeline README with 14/14 implemented nodes
- Added color-coded mermaid diagrams for better visualization
- Documented TCGA, CADD, ClinVar, PRS, and Pathway Burden models